### PR TITLE
set resource-dir default value to the buildout directory

### DIFF
--- a/jstools/bo.py
+++ b/jstools/bo.py
@@ -8,7 +8,10 @@ class BuildJS(object):
     @format for config
     """
     def __init__(self, buildout, name, options):
-        self.defaults = defaults = {'resource-dir':options.get('resource-dir')}
+        self.defaults = defaults = {
+                'resource-dir': options.get(
+                    'resource-dir', buildout['buildout']['directory'])
+                }
         defaults.update(options)
         self.options = options
         self.buildout = buildout


### PR DESCRIPTION
when resource-dir was not specified in the buildout.cfg, its default value
was set to None, which results in the following exception in ConfigParser:
TypeError: argument of type 'NoneType' is not iterable
