### PR TITLE
set base-dir and output-dir default values to the buildout directory (and few refactoring)

### DIFF
--- a/jstools/bo.py
+++ b/jstools/bo.py
@@ -8,10 +8,6 @@ class BuildJS(object):
     @format for config
     """
     def __init__(self, buildout, name, options):
-        self.defaults = {
-                'resource-dir': options.get(
-                    'resource-dir', buildout['buildout']['directory'])
-                }
         self.options = options
         self.buildout = buildout
         if options.get('output') is not None:
@@ -30,7 +26,10 @@ class BuildJS(object):
                 tuple(self.options.get('config').split()),
                 output_dir=self.options.get('output-dir', buildout_dir),
                 root_dir=self.options.get('base-dir', buildout_dir),
-                defaults=self.defaults,
+                defaults={
+                    'resource-dir': self.options.get(
+                        'resource-dir', buildout_dir)
+                },
                 printer=self.buildout._logger)
         files = self.merge.run(uncompressed=not self.compress, single=self.only)
         return files


### PR DESCRIPTION
When output-dir or base-dir were not specified in the buildout.cfg, their
default value were set to None, which causes an exception to be raised
